### PR TITLE
Fix #14. Revert "Introduced a bug in get_version()"

### DIFF
--- a/flask/cli.py
+++ b/flask/cli.py
@@ -260,7 +260,7 @@ def get_version(ctx, param, value):
         % {
             "python": platform.python_version(),
             "flask": __version__,
-            "werkzeug": werkzeug.version(),
+            "werkzeug": werkzeug.__version__,
         },
         color=ctx.color,
     )


### PR DESCRIPTION
This reverts commit e20dd06a, thereby fixing get_version(). This bug appears to have been introduced as part of #8.

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
