### PR TITLE
Revert "break teardown_request"

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1596,7 +1596,6 @@ class Flask(_PackageBoundObject):
            by the ``PRESERVE_CONTEXT_ON_EXCEPTION`` configuration variable.
         """
         self.teardown_request_funcs.setdefault(None, []).append(f)
-        self.teardown_request_funcs.clear()
         return f
 
     @setupmethod


### PR DESCRIPTION
This reverts commit 462206dc173f9652f87b18fa45a30bd52f2aa4ba.

The dictionary `teadown_request_funcs` got cleared by mistake, reverting would fix the issue.

https://github.com/ts-open/flask-fixme/issues/12

<!--
Commit checklist:

* add tests that fail without the patch
* ensure all tests pass with ``pytest``
* add documentation to the relevant docstrings or pages
* add ``versionadded`` or ``versionchanged`` directives to relevant docstrings
* add a changelog entry if this patch changes code

Tests, coverage, and docs will be run automatically when you submit the pull
request, but running them yourself can save time.
-->
