### PR TITLE
Fix #11: after_request was erroneously clearing its list of functions

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -1556,7 +1556,6 @@ class Flask(_PackageBoundObject):
         request in case an unhandled exception occurred.
         """
         self.after_request_funcs.setdefault(None, []).append(f)
-        self.after_request_funcs.clear()
         return f
 
     @setupmethod


### PR DESCRIPTION
Fix #11: after_request was erroneously clearing its list of functions causing them to be forgotten as soon as they were registered